### PR TITLE
[Feat] 스킬 요청 및 실행 결과 공용 계약 추가

### DIFF
--- a/Docs/DevelopmentOwnership.md
+++ b/Docs/DevelopmentOwnership.md
@@ -131,6 +131,109 @@ RAW_unity/Assets/_RAW/Scripts/Contracts/
 - 계약에는 Netcode, 구체적인 DB 구현, UI, 애니메이션과 VFX를 넣지 않는다.
 - enum 값은 기존 순서를 바꾸지 않고 명시적인 숫자를 유지한다.
 
+### 7.1 스킬 요청·실행 결과 계약
+
+초기 서버 권한 스킬 실행에는 다음 공용 계약을 사용한다.
+
+```text
+RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillUseRequest.cs
+RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillExecutionResult.cs
+RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillFailureReason.cs
+RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillEffectType.cs
+```
+
+계약 타입의 namespace는 `RAW.Contracts.Skills`를 사용한다. 계약에는 `NetworkObject`, `NetworkObjectReference`, RPC와 같은 Netcode 타입이나 `SkillSpec`과 같은 게임플레이 구현 타입을 넣지 않는다. Network와 Gameplay은 계약의 원시 값과 enum만 공유하고 각 영역에서 필요한 런타임 객체로 변환한다.
+
+#### 스킬 요청
+
+`SkillUseRequest`는 확정된 게임 결과가 아니라 Client의 스킬 사용 의도를 나타낸다.
+
+| 필드 | 의미 | 신뢰 및 검증 규칙 |
+| --- | --- | --- |
+| `RequestId` | Client가 생성한 요청 식별자 | `0`은 사용하지 않는다. 동일 요청을 재전송할 때는 같은 값을 사용하며 서버는 이미 처리한 값을 중복 적용하지 않는다. |
+| `Slot` | 사용하려는 `Q`, `W`, `E`, `R`, `A` 스킬 슬롯 | 서버가 해당 플레이어의 서버 권한 스킬 로드아웃에서 실제 스킬을 조회한다. |
+| `TargetEntityId` | Client가 선택한 대상 식별자 | 멀티플레이에서는 Network가 서버의 NetworkObject와 연결한다. 지정 대상이 없는 스킬은 `0`을 사용한다. |
+| `TargetPosition` | Client가 지정한 목표 월드 좌표 | Unity World Unit을 사용한다. 서버가 실제 시전자 위치, 사거리와 허용 가능한 위치인지 검증한다. |
+| `AimDirection` | Client가 지정한 조준 방향 | 방향형 스킬에서 사용한다. 서버가 값의 유효성을 검사하고 필요하면 정규화한다. |
+
+Client는 스킬 데미지, 사거리, 현재 MP, 쿨다운 종료 시각과 성공 여부를 요청에 포함하지 않는다. 요청에 포함된 대상, 위치와 방향도 검증된 사실로 취급하지 않는다.
+
+초기 계약에는 `ClientTick`을 포함하지 않는다. 현재 서버가 요청을 받은 시점의 서버 상태로 판정하며, 추후 지연 보정과 과거 위치 판정이 필요해질 때 허용 범위와 검증 규칙을 먼저 합의한 후 추가한다.
+
+#### 스킬 실행 결과
+
+`SkillExecutionResult`는 서버가 게임플레이 규칙을 호출한 뒤 확정하는 단일 스킬 효과 결과를 나타낸다.
+
+| 필드 | 의미 | 생성 및 적용 책임 |
+| --- | --- | --- |
+| `RequestId` | 결과와 원래 요청을 연결하는 식별자 | Network가 요청 값을 결과에 유지한다. |
+| `FailureReason` | 성공 또는 실패 이유 | Network와 Gameplay이 각자의 검증 책임에 맞는 값을 생성한다. `None`일 때만 성공이다. |
+| `TargetEntityId` | 효과를 적용할 대상 식별자 | Gameplay이 검증한 대상을 결과에 담고 Network가 서버의 실제 상태 객체로 연결한다. |
+| `EffectType` | `Damage`, `Heal` 또는 `None` | Gameplay이 스킬 규칙에 따라 결정한다. |
+| `Amount` | 적용할 데미지 또는 회복량 | Gameplay이 계산하며 0 이상의 정수를 사용한다. |
+| `ManaCost` | 성공 시 소모할 MP | Gameplay이 규칙에 따라 결정하고 Network가 서버 MP에 적용한다. |
+| `CooldownSeconds` | 성공 시 시작할 쿨다운 | 초 단위를 사용한다. Gameplay이 값을 결정하고 Network가 서버 시간으로 관리한다. |
+| `Succeeded` | 실행 성공 여부 | `FailureReason == None`으로 계산하며 별도 상태로 저장하거나 전송하지 않는다. |
+
+실패 결과에는 효과와 비용을 적용하지 않는다.
+
+```text
+FailureReason != None
+EffectType = None
+Amount = 0
+ManaCost = 0
+CooldownSeconds = 0
+```
+
+초기 계약은 한 번의 스킬 요청당 단일 `Damage` 또는 `Heal` 효과만 지원한다. 다단 히트, 타격 예약 시간, 버프·디버프, 넉백, 소환과 투사체 실행 ID는 실제 기능을 개발할 때 별도 계약 변경으로 추가한다.
+
+#### 실패 이유의 생성 책임
+
+| 실패 이유 | 담당 영역 |
+| --- | --- |
+| `InvalidRequest`, `DuplicateRequest`, `NotOwner` | 멀티·DB 담당 |
+| `SkillNotFound` | 멀티·DB 담당이 서버 스킬 로드아웃과 카탈로그를 기준으로 검사 |
+| `InvalidState`, `InsufficientMana`, `CooldownActive` | 멀티·DB 담당이 서버 상태를 제공하고 게임플레이 규칙이 사용 가능 여부를 판단 |
+| `InvalidTarget`, `TargetDead`, `OutOfRange`, `Blocked` | 게임플레이 담당의 규칙 검증 |
+
+실패 이유 enum은 기존 숫자를 변경하거나 다른 의미로 재사용하지 않는다. 표시 문구와 다국어 처리는 계약 enum이 아니라 UI 영역에서 담당한다.
+
+#### 호출과 상태 적용 순서
+
+```text
+게임플레이 담당
+입력·대상 선택 → SkillUseRequest에 필요한 의도 제공
+                         ↓
+멀티·DB 담당
+RequestId 생성 → 서버 전송 → 소유권·중복·대상 존재 검사
+                         ↓
+멀티·DB 담당
+서버의 실제 위치·HP·MP·쿨다운과 대상 상태 조회
+                         ↓
+게임플레이 담당 코드
+사거리·대상·장애물 검증 → 효과·MP 비용·쿨다운 계산
+                         ↓
+멀티·DB 담당
+SkillExecutionResult 확정 → 서버 상태에 한 번 적용 → 결과 동기화
+                         ↓
+게임플레이 담당 코드
+애니메이션·이펙트·사운드 표시
+```
+
+멀티플레이에서는 Network가 서버 상태 변경의 유일한 적용 지점이다. 게임플레이 규칙은 결과를 계산해 반환하고 Network가 HP, MP와 쿨다운에 결과를 한 번만 적용한다. Client의 스킬 이펙트와 충돌 오브젝트는 상태를 직접 변경하지 않는다.
+
+오프라인에서는 Local Runtime이 같은 게임플레이 규칙을 호출한 뒤 결과를 로컬 상태에 적용한다. 게임플레이 규칙을 오프라인용과 서버용으로 복사해 구현하지 않는다.
+
+#### 계약 검증
+
+계약의 성공·실패 생성 규칙과 enum 숫자는 다음 EditMode 테스트에서 검증한다.
+
+```text
+RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/SkillExecutionContractTests.cs
+```
+
+계약을 변경하는 Pull Request에서는 `RAW.Contracts.Tests.EditMode` 테스트를 실행하고 두 담당자가 변경 의미와 하위 호환성을 함께 리뷰한다.
+
 ## 8. 주요 기능의 연결 방식
 
 ### 8.1 스킬과 전투

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills.meta
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe8fce29c842f43f38c0cd37fb394346
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillEffectType.cs
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillEffectType.cs
@@ -1,0 +1,9 @@
+namespace RAW.Contracts.Skills
+{
+	public enum SkillEffectType
+	{
+		None = 0,
+		Damage = 1,
+		Heal = 2
+	}
+}

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillEffectType.cs.meta
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillEffectType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d907886c20cbc4853b346e429748cc7a

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillExecutionResult.cs
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillExecutionResult.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace RAW.Contracts.Skills
+{
+	[Serializable]
+	public struct SkillExecutionResult
+	{
+		public ulong ReqeustId;
+
+		public SkillFailureReason FailureReason;
+		
+		public ulong TargetEntityId;
+		public SkillEffectType EffectType;
+		public int Amount;
+
+		public int ManaCost;
+		public float CooldownSeconds;
+
+		public bool Succeeded => FailureReason == SkillFailureReason.None;
+
+		public static SkillExecutionResult Rejected(
+			ulong requestId,
+			SkillFailureReason failureReason,
+			ulong targetEntityId = 0)
+		{
+			if (failureReason == SkillFailureReason.None)
+				failureReason = SkillFailureReason.InvalidRequest;
+
+			return new SkillExecutionResult
+			{
+				ReqeustId = requestId,
+				FailureReason = failureReason,
+
+				TargetEntityId = targetEntityId,
+				EffectType = SkillEffectType.None,
+				Amount = 0,
+
+				ManaCost = 0,
+				CooldownSeconds = 0f
+			};
+		}
+
+
+		public static SkillExecutionResult Success(
+			ulong requestId,
+			ulong targetEntityId,
+			SkillEffectType effectType,
+			int amount,
+			int manaCost,
+			float cooldownSeconds
+		)
+		{
+			return new SkillExecutionResult
+			{
+				ReqeustId = requestId,
+				FailureReason = SkillFailureReason.None,
+
+				TargetEntityId = targetEntityId,
+				EffectType = effectType,
+				Amount = Math.Max(0, amount),
+
+				ManaCost = Math.Max(0, manaCost),
+				CooldownSeconds = Math.Max(0f, cooldownSeconds)
+			};
+		}
+	}
+}

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillExecutionResult.cs
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillExecutionResult.cs
@@ -5,7 +5,7 @@ namespace RAW.Contracts.Skills
 	[Serializable]
 	public struct SkillExecutionResult
 	{
-		public ulong ReqeustId;
+		public ulong RequestId;
 
 		public SkillFailureReason FailureReason;
 		
@@ -28,7 +28,7 @@ namespace RAW.Contracts.Skills
 
 			return new SkillExecutionResult
 			{
-				ReqeustId = requestId,
+				RequestId = requestId,
 				FailureReason = failureReason,
 
 				TargetEntityId = targetEntityId,
@@ -52,7 +52,7 @@ namespace RAW.Contracts.Skills
 		{
 			return new SkillExecutionResult
 			{
-				ReqeustId = requestId,
+				RequestId = requestId,
 				FailureReason = SkillFailureReason.None,
 
 				TargetEntityId = targetEntityId,

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillExecutionResult.cs.meta
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillExecutionResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f832f94c0d3d6462c8313f6e31aee5d3

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillFailureReason.cs
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillFailureReason.cs
@@ -8,7 +8,7 @@ namespace RAW.Contracts.Skills
 		DuplicateRequest = 2,
 		NotOwner = 3,
 
-		SkillNotFount = 10,
+		SkillNotFound = 10,
 		InvalidState = 11,
 		InsufficientMana = 12,
 		CooldownActive = 13,

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillFailureReason.cs
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillFailureReason.cs
@@ -1,0 +1,21 @@
+namespace RAW.Contracts.Skills
+{
+	public enum SkillFailureReason
+	{
+		None = 0,
+
+		InvalidRequest = 1,
+		DuplicateRequest = 2,
+		NotOwner = 3,
+
+		SkillNotFount = 10,
+		InvalidState = 11,
+		InsufficientMana = 12,
+		CooldownActive = 13,
+
+		InvalidTarget = 20,
+		TargetDead = 21,
+		OutOfRange = 22,
+		Blocked = 23
+	}
+}

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillFailureReason.cs.meta
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillFailureReason.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d611204dfa26c47dcb67196f271eddd8

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillUseRequest.cs
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillUseRequest.cs
@@ -1,0 +1,16 @@
+using System;
+using UnityEngine;
+
+namespace RAW.Contracts.Skills
+{
+	[Serializable]
+	public struct SkillUseRequest
+	{
+		public ulong ReqeustId;
+		public KeyMapping Slot;
+
+		public ulong TargetEntityId;
+		public Vector2 TargetPosition;
+		public Vector2 AimDirecton;
+	}
+}

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillUseRequest.cs
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillUseRequest.cs
@@ -6,11 +6,11 @@ namespace RAW.Contracts.Skills
 	[Serializable]
 	public struct SkillUseRequest
 	{
-		public ulong ReqeustId;
+		public ulong RequestId;
 		public KeyMapping Slot;
 
 		public ulong TargetEntityId;
 		public Vector2 TargetPosition;
-		public Vector2 AimDirecton;
+		public Vector2 AimDirection;
 	}
 }

--- a/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillUseRequest.cs.meta
+++ b/RAW_unity/Assets/_RAW/Scripts/Contracts/Skills/SkillUseRequest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2e6482200b9d74cf0845ec7b606e92c5

--- a/RAW_unity/Assets/_RAW/Tests.meta
+++ b/RAW_unity/Assets/_RAW/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a242545a0562942578cdac70e24fb860
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RAW_unity/Assets/_RAW/Tests/EditMode.meta
+++ b/RAW_unity/Assets/_RAW/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd1dd62db7b80481797d89ed14d50c5f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts.meta
+++ b/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c26cfb0d9aa5e4c618b13a201e81b31b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/RAW.Contracts.Tests.EditMode.asmdef
+++ b/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/RAW.Contracts.Tests.EditMode.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "RAW.Contracts.Tests.EditMode",
+    "rootNamespace": "RAW.Contracts.Tests.EditMode",
+    "references": [
+        "GUID:006236d6931fa4bad9a1ca4a5079e85a"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/RAW.Contracts.Tests.EditMode.asmdef.meta
+++ b/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/RAW.Contracts.Tests.EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 49bec30275bbb4b33a11a57b3f365dd3
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/SkillExecutionContractTests.cs
+++ b/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/SkillExecutionContractTests.cs
@@ -1,0 +1,180 @@
+using NUnit.Framework;
+using RAW.Contracts.Skills;
+
+namespace RAW.Contracts.Tests.EditMode
+{
+    public class SkillExecutionContractTests
+    {
+        [Test]
+        public void Rejected_ReturnsFailedResult()
+        {
+            SkillExecutionResult result =
+                SkillExecutionResult.Rejected(
+                    requestId: 10,
+                    failureReason: SkillFailureReason.OutOfRange,
+                    targetEntityId: 20
+                );
+
+            Assert.That(result.Succeeded, Is.False);
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SkillFailureReason.OutOfRange)
+            );
+
+            Assert.That(result.RequestId, Is.EqualTo(10UL));
+            Assert.That(result.TargetEntityId, Is.EqualTo(20UL));
+        }
+
+        [Test]
+        public void Rejected_ClearsEffectAndCosts()
+        {
+            SkillExecutionResult result =
+                SkillExecutionResult.Rejected(
+                    requestId: 10,
+                    failureReason: SkillFailureReason.InvalidTarget,
+                    targetEntityId: 20
+                );
+
+            Assert.That(
+                result.EffectType,
+                Is.EqualTo(SkillEffectType.None)
+            );
+
+            Assert.That(result.Amount, Is.Zero);
+            Assert.That(result.ManaCost, Is.Zero);
+            Assert.That(result.CooldownSeconds, Is.Zero);
+        }
+
+        [Test]
+        public void Rejected_WithNoneReason_UsesInvalidRequest()
+        {
+            SkillExecutionResult result =
+                SkillExecutionResult.Rejected(
+                    requestId: 10,
+                    failureReason: SkillFailureReason.None
+                );
+
+            Assert.That(result.Succeeded, Is.False);
+
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SkillFailureReason.InvalidRequest)
+            );
+        }
+
+        [Test]
+        public void Success_PreservesValidValues()
+        {
+            SkillExecutionResult result =
+                SkillExecutionResult.Success(
+                    requestId: 10,
+                    targetEntityId: 20,
+                    effectType: SkillEffectType.Damage,
+                    amount: 30,
+                    manaCost: 10,
+                    cooldownSeconds: 2f
+                );
+
+            Assert.That(result.Succeeded, Is.True);
+
+            Assert.That(
+                result.FailureReason,
+                Is.EqualTo(SkillFailureReason.None)
+            );
+
+            Assert.That(result.RequestId, Is.EqualTo(10UL));
+            Assert.That(result.TargetEntityId, Is.EqualTo(20UL));
+
+            Assert.That(
+                result.EffectType,
+                Is.EqualTo(SkillEffectType.Damage)
+            );
+
+            Assert.That(result.Amount, Is.EqualTo(30));
+            Assert.That(result.ManaCost, Is.EqualTo(10));
+            Assert.That(result.CooldownSeconds, Is.EqualTo(2f));
+        }
+
+        [Test]
+        public void Success_ClampsNegativeValuesToZero()
+        {
+            SkillExecutionResult result =
+                SkillExecutionResult.Success(
+                    requestId: 10,
+                    targetEntityId: 20,
+                    effectType: SkillEffectType.Damage,
+                    amount: -30,
+                    manaCost: -10,
+                    cooldownSeconds: -2f
+                );
+
+            Assert.That(result.Succeeded, Is.True);
+            Assert.That(result.Amount, Is.Zero);
+            Assert.That(result.ManaCost, Is.Zero);
+            Assert.That(result.CooldownSeconds, Is.Zero);
+        }
+
+        [Test]
+        public void FailureReason_UsesStableNumericValues()
+        {
+            Assert.That(
+                (int)SkillFailureReason.None,
+                Is.EqualTo(0)
+            );
+
+            Assert.That(
+                (int)SkillFailureReason.InvalidRequest,
+                Is.EqualTo(1)
+            );
+
+            Assert.That(
+                (int)SkillFailureReason.DuplicateRequest,
+                Is.EqualTo(2)
+            );
+
+            Assert.That(
+                (int)SkillFailureReason.NotOwner,
+                Is.EqualTo(3)
+            );
+
+            Assert.That(
+                (int)SkillFailureReason.SkillNotFound,
+                Is.EqualTo(10)
+            );
+
+            Assert.That(
+                (int)SkillFailureReason.InsufficientMana,
+                Is.EqualTo(12)
+            );
+
+            Assert.That(
+                (int)SkillFailureReason.InvalidTarget,
+                Is.EqualTo(20)
+            );
+
+            Assert.That(
+                (int)SkillFailureReason.OutOfRange,
+                Is.EqualTo(22)
+            );
+        }
+
+        [Test]
+        public void EffectType_UsesStableNumericValues()
+        {
+            Assert.That(
+                (int)SkillEffectType.None,
+                Is.EqualTo(0)
+            );
+
+            Assert.That(
+                (int)SkillEffectType.Damage,
+                Is.EqualTo(1)
+            );
+
+            Assert.That(
+                (int)SkillEffectType.Heal,
+                Is.EqualTo(2)
+            );
+        }
+    }
+}

--- a/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/SkillExecutionContractTests.cs.meta
+++ b/RAW_unity/Assets/_RAW/Tests/EditMode/Contracts/SkillExecutionContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d7df65ab408f4359819a29dc1b96f34


### PR DESCRIPTION
## 작업 목적

게임플레이와 멀티플레이가 스킬 기능을 독립적으로 구현할 수 있도록 스킬 사용 요청과 실행 결과의 공용 계약을 정의했습니다.

이번 PR은 실제 스킬 실행이나 네트워크 처리를 구현하지 않고, 두 영역이 공유할 데이터 구조와 책임 경계만 추가합니다.

## 주요 변경 사항

### 스킬 사용 요청 계약

`SkillUseRequest`를 추가했습니다.

- 요청 식별자
- 사용할 스킬 슬롯
- 대상 Entity ID
- 목표 위치
- 조준 방향

Client가 보내는 값은 확정된 결과가 아닌 “스킬 사용 의도”로 취급하며, 데미지·MP·쿨다운·성공 여부는 요청에 포함하지 않습니다.

### 스킬 실행 결과 계약

`SkillExecutionResult`를 추가했습니다.

- 요청 식별자
- 성공 또는 실패 사유
- 효과 대상
- 데미지 또는 회복 효과
- 효과 수치
- MP 소모량
- 쿨다운

성공 결과와 실패 결과를 일관되게 생성할 수 있도록 `Success`, `Rejected` 생성 함수를 제공합니다.

- 실패 결과는 효과와 비용을 0으로 초기화
- 음수 효과량, MP 비용, 쿨다운은 0으로 보정
- `FailureReason == None`인 경우에만 성공으로 판정

### 공용 enum 추가

다음 enum을 추가했습니다.

- `SkillEffectType`
  - None
  - Damage
  - Heal
- `SkillFailureReason`
  - 요청 오류, 중복 요청, 소유권 오류
  - 스킬·상태·MP·쿨다운 오류
  - 대상·사거리·장애물 오류

네트워크 전송 및 하위 호환성을 고려해 enum 숫자를 명시적으로 고정했습니다.

### 계약 테스트 추가

Unity EditMode 계약 테스트를 추가했습니다.

- 성공 결과 값 유지
- 실패 결과의 효과와 비용 초기화
- 잘못된 실패 사유 보정
- 음수 값 보정
- 실패 사유 enum 숫자 검증
- 효과 타입 enum 숫자 검증

### 책임 경계 문서화

`DevelopmentOwnership.md`에 다음 내용을 추가했습니다.

- 스킬 요청과 실행 결과의 필드 의미
- Client 요청값의 신뢰 및 검증 규칙
- 게임플레이와 멀티플레이의 검증 책임
- 서버 상태 적용 순서
- 실패 결과 생성 규칙
- 초기 계약의 지원 범위

## 책임 구분

### 게임플레이 담당

- 대상 및 사거리 검증
- 장애물 검증
- 데미지·회복량 계산
- MP 비용과 쿨다운 계산
- 애니메이션·이펙트·사운드 표시

### 멀티·DB 담당

- 요청 전송
- 소유권 및 중복 요청 검사
- 서버 상태 조회
- 계산 결과를 서버 상태에 한 번만 적용
- 결과 동기화 및 저장

## 이번 PR에 포함되지 않는 내용

- 실제 RPC 및 네트워크 실행 흐름
- HP·MP·쿨다운 상태 적용
- 스킬 데미지 계산 규칙
- 스킬 애니메이션 및 이펙트
- 다단 히트, 버프·디버프, 넉백, 소환
- DB 저장 구현
- Scene 및 Prefab 변경

## 리뷰 요청 사항

- 요청 필드가 게임플레이 입력을 표현하기에 충분한지
- 게임플레이와 멀티플레이의 검증 책임이 적절한지
- 성공·실패 결과 구조가 이후 구현에 적합한지
- 초기 계약을 단일 Damage 또는 Heal 효과로 제한해도 되는지
- enum 숫자와 실패 사유 구분이 적절한지